### PR TITLE
Fixed bug where replace wasn't called correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ def _fix_package_name(package_name: str) -> str:
     fixed_package_name = package_name.replace('-', '_')
     # Special case for the 'backports' modules.
     if fixed_package_name.startswith('backports_'):
-        fixed_package_name.replace('_', '.', count=1)
+        fixed_package_name.replace('_', '.', 1)
     return fixed_package_name
 
 


### PR DESCRIPTION
replace was called with keyword argument 'count' instead of as a positional argument.
Consider rechecking the testing process to avoid such errors in the future, maybe on the remote CI machine this code wasn't reached.
